### PR TITLE
fix crash when there is large track for started monitoring

### DIFF
--- a/app/src/main/java/org/bspb/smartbirds/pro/ui/MonitoringActivity.java
+++ b/app/src/main/java/org/bspb/smartbirds/pro/ui/MonitoringActivity.java
@@ -108,7 +108,6 @@ public class MonitoringActivity extends BaseActivity implements ServiceConnectio
     @Bean
     EEventBus eventBus;
 
-    @InstanceState
     @NonNull
     ArrayList<LatLng> points = new ArrayList<LatLng>();
     @InstanceState


### PR DESCRIPTION
Remove storing track points in instance state because app is crashing if the track is too large. Storing of the track is done in shared prefs and there is no need to store it in the state bundle.

Below is the stack trace of the exception thrown when track becomes too large

> Fatal Exception: java.lang.RuntimeException: android.os.TransactionTooLargeException: data parcel size 548264 bytes
       at android.app.ActivityThread$StopInfo.run(ActivityThread.java:4238)
       at android.os.Handler.handleCallback(Handler.java:751)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at android.os.Looper.loop(Looper.java:154)
       at android.app.ActivityThread.main(ActivityThread.java:6816)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1563)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1451)