### PR TITLE
Fix Android CI: free disk space before emulator boot

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,17 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
+      - name: free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          android: false
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: set up JDK 17
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
Free disk space before emulator boot to fix AVD creation failures on recent ubuntu-latest runner images.